### PR TITLE
Convert to container infrastructure for travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 cache: bundler
 script: "TESTOPTS=-v bundle exec rake test"


### PR DESCRIPTION
Fixes this 'This job ran on our legacy infrastructure.'
